### PR TITLE
Add disableCookies to Matomo script

### DIFF
--- a/resources/views/piwik.blade.php
+++ b/resources/views/piwik.blade.php
@@ -4,7 +4,7 @@
 
         _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);
-
+        _paq.push(['disableCookies']);
         (function () {
             var u = "{{ $url}}";
             _paq.push(['setTrackerUrl', u + 'piwik.php']);


### PR DESCRIPTION
In order to be GDPR-compliant without consent banner, cookies and fingerprinting
must be disabled which this change does.

When using the traffic.okfn.de Matomo instance, please also point to our [privacy policy](https://okfn.de/impressum/#datenschutzerkl%C3%A4rung) which describes data handling details and the opt-out process.